### PR TITLE
Fix auth/me endpoint session error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,23 @@ class ApplicationController < ActionController::API
   respond_to :json
   
   before_action :configure_permitted_parameters, if: :devise_controller?
+  attr_reader :current_user
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation])
+  end
+
+  def authenticate_user!
+    header = request.headers['Authorization']
+    token = header.split(' ').last if header
+    
+    begin
+      decoded = JWT.decode(token, Rails.application.credentials.secret_key_base || 'development_jwt_secret', true, { algorithm: 'HS256' })
+      @current_user = User.find(decoded[0]['sub'])
+    rescue JWT::DecodeError, ActiveRecord::RecordNotFound
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+    end
   end
 end


### PR DESCRIPTION
# Fix auth/me endpoint session error

## Description
This PR fixes the 500 Internal Server Error that occurs when accessing the `/api/v1/auth/me` endpoint with a JWT token. The error was caused by the application trying to use sessions which are disabled in API-only mode.

## Changes
- Restored the JWT authentication functionality in ApplicationController
- Added the current_user attribute reader
- Implemented the authenticate_user! method to properly handle JWT tokens without relying on sessions

## Testing
- Tested the endpoint with a valid JWT token to ensure it works correctly
- Verified no session-related errors occur

Link to Devin run: https://app.devin.ai/sessions/149f6205bd7f43fda67d9a10cd09de59
Requested by: caio.ramos@smartfit.com
